### PR TITLE
Settings: replace "Network" through "Services" in settings

### DIFF
--- a/addons/skin.confluence/720p/Settings.xml
+++ b/addons/skin.confluence/720p/Settings.xml
@@ -153,10 +153,10 @@
 						<icon>special://skin/backgrounds/addons.jpg</icon>
 					</item>
 					<item id="7">
-						<label>705</label>
-						<label2>31405</label2>
-						<onclick>ActivateWindow(NetworkSettings)</onclick>
-						<icon>special://skin/backgrounds/network.jpg</icon>
+						<label>14036</label>
+						<label2>31409</label2>
+						<onclick>ActivateWindow(ServiceSettings)</onclick>
+						<icon>special://skin/backgrounds/services.jpg</icon>
 					</item>
 					<item id="8">
 						<label>13000</label>

--- a/addons/skin.confluence/language/English/strings.xml
+++ b/addons/skin.confluence/language/English/strings.xml
@@ -158,10 +158,11 @@
   <string id="31402">[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission · Set karaoke options</string>
   <string id="31403">[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshows</string>
   <string id="31404">[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information</string>
-  <string id="31405">[B]CONFIGURE NETWORK SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Set internet access options</string>
+
   <string id="31406">[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock</string>
   <string id="31407">[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin · Add and remove home menu items[CR]Change skin backgrounds</string>
   <string id="31408">[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings</string>
+  <string id="31409">[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay</string>
 
   <string id="31421">Select your XBMC user Profile[CR]to login and continue</string>
   

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -692,7 +692,7 @@
   <string id="787">Interface disabled</string>
   <string id="788">Network interface disabled successfully.</string>
   <string id="789">Wireless network name (ESSID)</string>
-
+  <string id="790">Remote control</string>
   <string id="791">Allow programs on this system to control XBMC</string>
   <string id="792">Port</string>
   <string id="793">Port range</string>
@@ -803,10 +803,12 @@
   <string id="1256">Ping interval</string>
   <string id="1257">Would you like to connect to the auto-detected system?</string>
 
+  <string id="1259">Zeroconf</string>
   <string id="1260">Announce these services to other systems via Zeroconf</string>
   <string id="1270">Allow XBMC to receive AirPlay content</string>
   <string id="1271">Device name</string>
   <string id="1272">- Use password protection</string>
+  <string id="1273">AirPlay</string>
 
   <string id="1300">Custom audio device</string>
   <string id="1301">Custom passthrough device</string>
@@ -1722,6 +1724,7 @@
   <string id="20184">Rotate pictures using EXIF information</string>
   <string id="20185">Use poster view styles for TV shows</string>
   <string id="20186">Please wait</string>
+  <string id="20187">UPnP</string>
 
   <string id="20189">Enable auto scrolling for plot &amp; review</string>
   <string id="20190">Custom</string>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3228,7 +3228,7 @@ bool CApplication::Cleanup()
     g_windowManager.Remove(WINDOW_SETTINGS_MYMUSIC);
     g_windowManager.Remove(WINDOW_SETTINGS_SYSTEM);
     g_windowManager.Remove(WINDOW_SETTINGS_MYVIDEOS);
-    g_windowManager.Remove(WINDOW_SETTINGS_NETWORK);
+    g_windowManager.Remove(WINDOW_SETTINGS_SERVICES);
     g_windowManager.Remove(WINDOW_SETTINGS_APPEARANCE);
     g_windowManager.Remove(WINDOW_DIALOG_KAI_TOAST);
 

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -324,7 +324,7 @@
 #define WINDOW_SETTINGS_MYMUSIC           10015
 #define WINDOW_SETTINGS_SYSTEM            10016
 #define WINDOW_SETTINGS_MYVIDEOS          10017
-#define WINDOW_SETTINGS_NETWORK           10018
+#define WINDOW_SETTINGS_SERVICES          10018
 #define WINDOW_SETTINGS_APPEARANCE        10019
 
 #define WINDOW_SCRIPTS                    10020 // virtual window for backward compatibility

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -236,7 +236,7 @@ static const ActionMapping windows[] =
         {"musicsettings"            , WINDOW_SETTINGS_MYMUSIC},
         {"systemsettings"           , WINDOW_SETTINGS_SYSTEM},
         {"videossettings"           , WINDOW_SETTINGS_MYVIDEOS},
-        {"networksettings"          , WINDOW_SETTINGS_NETWORK},
+        {"servicesettings"          , WINDOW_SETTINGS_SERVICES},
         {"appearancesettings"       , WINDOW_SETTINGS_APPEARANCE},
         {"scripts"                  , WINDOW_PROGRAMS}, // backward compat
         {"videofiles"               , WINDOW_VIDEO_FILES},

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -222,7 +222,7 @@ void CSettingsGroup::GetCategories(vecSettingsCategory &vecCategories)
   {
     vecSettings settings;
     // check whether we actually have these settings available.
-    g_guiSettings.GetSettingsGroup(m_vecCategories[i]->m_strCategory, settings);
+    g_guiSettings.GetSettingsGroup(m_vecCategories[i], settings);
     if (settings.size())
       vecCategories.push_back(m_vecCategories[i]);
   }
@@ -489,6 +489,44 @@ void CGUISettings::Initialize()
   AddBool(in, "input.enablemouse", 21369, true);
 #endif
 
+  CSettingsCategory* net = AddCategory(4, "network", 798);
+  if (g_application.IsStandAlone())
+  {
+#ifndef __APPLE__
+    AddString(NULL, "network.interface",775,"", SPIN_CONTROL_TEXT);
+
+    map<int, int> networkAssignments;
+    networkAssignments.insert(make_pair(716, NETWORK_DHCP));
+    networkAssignments.insert(make_pair(717, NETWORK_STATIC));
+    networkAssignments.insert(make_pair(787, NETWORK_DISABLED));
+    AddInt(NULL, "network.assignment", 715, NETWORK_DHCP, networkAssignments, SPIN_CONTROL_TEXT);
+    AddString(NULL, "network.ipaddress", 719, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+    AddString(NULL, "network.subnet", 720, "255.255.255.0", EDIT_CONTROL_IP_INPUT);
+    AddString(NULL, "network.gateway", 721, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+    AddString(NULL, "network.dns", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+    AddString(NULL, "network.dnssuffix", 22002, "", EDIT_CONTROL_INPUT, true);
+    AddString(NULL, "network.essid", 776, "0.0.0.0", BUTTON_CONTROL_STANDARD);
+
+    map<int, int> networkEncapsulations;
+    networkEncapsulations.insert(make_pair(780, ENC_NONE));
+    networkEncapsulations.insert(make_pair(781, ENC_WEP));
+    networkEncapsulations.insert(make_pair(782, ENC_WPA));
+    networkEncapsulations.insert(make_pair(783, ENC_WPA2));
+    AddInt(NULL, "network.enc", 778, ENC_NONE, networkEncapsulations, SPIN_CONTROL_TEXT);
+    AddString(NULL, "network.key", 777, "0.0.0.0", EDIT_CONTROL_INPUT);
+#ifndef _WIN32
+    AddString(NULL, "network.save", 779, "", BUTTON_CONTROL_STANDARD);
+#endif
+    AddSeparator(NULL, "network.sep1");
+#endif
+  }
+  AddBool(net, "network.usehttpproxy", 708, false);
+  AddString(net, "network.httpproxyserver", 706, "", EDIT_CONTROL_INPUT);
+  AddString(net, "network.httpproxyport", 730, "8080", EDIT_CONTROL_NUMBER_INPUT, false, 707);
+  AddString(net, "network.httpproxyusername", 1048, "", EDIT_CONTROL_INPUT);
+  AddString(net, "network.httpproxypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT,true,733);
+  AddInt(net, "network.bandwidth", 14041, 0, 0, 512, 100*1024, SPIN_CONTROL_INT_PLUS, MASK_KBPS, TEXT_OFF);
+
   CSettingsCategory* pwm = AddCategory(4, "powermanagement", 14095);
   // Note: Application.cpp might hide powersaving settings if not supported.
   AddInt(pwm, "powermanagement.displaysoff", 1450, 0, 0, 5, 120, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF);
@@ -708,96 +746,59 @@ void CGUISettings::Initialize()
   AddDefaultAddon(NULL, "scrapers.musicvideosdefault", 21415, "metadata.yahoomusic.com", ADDON_SCRAPER_MUSICVIDEOS);
   AddBool(NULL, "scrapers.langfallback", 21416, false);
 
-  // network settings
-  AddGroup(6, 705);
+  // service settings
+  AddGroup(6, 14036);
 
-  CSettingsCategory* srv = AddCategory(6, "services", 14036);
-  AddString(srv,"services.devicename", 1271, "XBMC", EDIT_CONTROL_INPUT);
-  AddSeparator(srv,"services.sep4");
-  AddBool(srv, "services.upnpserver", 21360, false);
-  AddBool(srv, "services.upnprenderer", 21881, false);
-  AddSeparator(srv,"services.sep3");
+  CSettingsCategory* srvGeneral = AddCategory(6, "general", 16000);
+  AddString(srvGeneral,"services.devicename", 1271, "XBMC", EDIT_CONTROL_INPUT);
+
+  CSettingsCategory* srvUpnp = AddCategory(6, "upnp", 20187);
+  AddBool(srvUpnp, "services.upnpserver", 21360, false);
+  AddBool(srvUpnp, "services.upnprenderer", 21881, false);
+
 #ifdef HAS_WEB_SERVER
-  AddBool(srv,  "services.webserver",        263, false);
+  CSettingsCategory* srvWeb = AddCategory(6, "webserver", 33101);
+  AddBool(srvWeb,  "services.webserver",        263, false);
 #ifdef _LINUX
-  AddString(srv,"services.webserverport",    730, (geteuid()==0)?"80":"8080", EDIT_CONTROL_NUMBER_INPUT, false, 730);
+  AddString(srvWeb,"services.webserverport",    730, (geteuid()==0)?"80":"8080", EDIT_CONTROL_NUMBER_INPUT, false, 730);
 #else
-  AddString(srv,"services.webserverport",    730, "80", EDIT_CONTROL_NUMBER_INPUT, false, 730);
+  AddString(srvWeb,"services.webserverport",    730, "80", EDIT_CONTROL_NUMBER_INPUT, false, 730);
 #endif
-  AddString(srv,"services.webserverusername",1048, "xbmc", EDIT_CONTROL_INPUT);
-  AddString(srv,"services.webserverpassword",733, "", EDIT_CONTROL_HIDDEN_INPUT, true, 733);
-  AddDefaultAddon(srv, "services.webskin",199, DEFAULT_WEB_INTERFACE, ADDON_WEB_INTERFACE);
+  AddString(srvWeb,"services.webserverusername",1048, "xbmc", EDIT_CONTROL_INPUT);
+  AddString(srvWeb,"services.webserverpassword",733, "", EDIT_CONTROL_HIDDEN_INPUT, true, 733);
+  AddDefaultAddon(srvWeb, "services.webskin",199, DEFAULT_WEB_INTERFACE, ADDON_WEB_INTERFACE);
 #endif
 #ifdef HAS_EVENT_SERVER
-  AddSeparator(srv,"services.sep1");
-  AddBool(srv,  "services.esenabled",         791, true);
+  CSettingsCategory* srvEvent = AddCategory(6, "remotecontrol", 790);
+  AddBool(srvEvent,  "services.esenabled",         791, true);
   AddString(NULL,"services.esport",            792, "9777", EDIT_CONTROL_NUMBER_INPUT, false, 792);
   AddInt(NULL,   "services.esportrange",       793, 10, 1, 1, 100, SPIN_CONTROL_INT);
   AddInt(NULL,   "services.esmaxclients",      797, 20, 1, 1, 100, SPIN_CONTROL_INT);
-  AddBool(srv,  "services.esallinterfaces",   794, false);
+  AddBool(srvEvent,  "services.esallinterfaces",   794, false);
   AddInt(NULL,   "services.esinitialdelay",    795, 750, 5, 5, 10000, SPIN_CONTROL_INT);
   AddInt(NULL,   "services.escontinuousdelay", 796, 25, 5, 5, 10000, SPIN_CONTROL_INT);
 #endif
 #ifdef HAS_ZEROCONF
-  AddSeparator(srv, "services.sep2");
+  CSettingsCategory* srvZeroconf = AddCategory(6, "zeroconf", 1259);
 #ifdef TARGET_WINDOWS
-  AddBool(srv, "services.zeroconf", 1260, false);
+  AddBool(srvZeroconf, "services.zeroconf", 1260, false);
 #else
-  AddBool(srv, "services.zeroconf", 1260, true);
+  AddBool(srvZeroconf, "services.zeroconf", 1260, true);
 #endif
 #endif
 
 #ifdef HAS_AIRPLAY
-  AddSeparator(srv, "services.sep5");
-  AddBool(srv, "services.airplay", 1270, false);
-  AddBool(srv, "services.useairplaypassword", 1272, false);
-  AddString(srv, "services.airplaypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT, false, 733);
-  AddSeparator(srv, "services.sep6");  
+  CSettingsCategory* srvAirplay = AddCategory(6, "airplay", 1273);
+  AddBool(srvAirplay, "services.airplay", 1270, false);
+  AddBool(srvAirplay, "services.useairplaypassword", 1272, false);
+  AddString(srvAirplay, "services.airplaypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT, false, 733); 
 #endif
 
 #ifndef _WIN32
-  CSettingsCategory* smb = AddCategory(6, "smb", 1200);
-  AddString(smb, "smb.winsserver",  1207,   "",  EDIT_CONTROL_IP_INPUT);
-  AddString(smb, "smb.workgroup",   1202,   "WORKGROUP", EDIT_CONTROL_INPUT, false, 1202);
+  CSettingsCategory* srvSmb = AddCategory(6, "smb", 1200);
+  AddString(srvSmb, "smb.winsserver",  1207,   "",  EDIT_CONTROL_IP_INPUT);
+  AddString(srvSmb, "smb.workgroup",   1202,   "WORKGROUP", EDIT_CONTROL_INPUT, false, 1202);
 #endif
-
-  CSettingsCategory* net = AddCategory(6, "network", 798);
-  if (g_application.IsStandAlone())
-  {
-#ifndef __APPLE__
-    AddString(NULL, "network.interface",775,"", SPIN_CONTROL_TEXT);
-
-    map<int, int> networkAssignments;
-    networkAssignments.insert(make_pair(716, NETWORK_DHCP));
-    networkAssignments.insert(make_pair(717, NETWORK_STATIC));
-    networkAssignments.insert(make_pair(787, NETWORK_DISABLED));
-    AddInt(NULL, "network.assignment", 715, NETWORK_DHCP, networkAssignments, SPIN_CONTROL_TEXT);
-    AddString(NULL, "network.ipaddress", 719, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-    AddString(NULL, "network.subnet", 720, "255.255.255.0", EDIT_CONTROL_IP_INPUT);
-    AddString(NULL, "network.gateway", 721, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-    AddString(NULL, "network.dns", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-    AddString(NULL, "network.dnssuffix", 22002, "", EDIT_CONTROL_INPUT, true);
-    AddString(NULL, "network.essid", 776, "0.0.0.0", BUTTON_CONTROL_STANDARD);
-
-    map<int, int> networkEncapsulations;
-    networkEncapsulations.insert(make_pair(780, ENC_NONE));
-    networkEncapsulations.insert(make_pair(781, ENC_WEP));
-    networkEncapsulations.insert(make_pair(782, ENC_WPA));
-    networkEncapsulations.insert(make_pair(783, ENC_WPA2));
-    AddInt(NULL, "network.enc", 778, ENC_NONE, networkEncapsulations, SPIN_CONTROL_TEXT);
-    AddString(NULL, "network.key", 777, "0.0.0.0", EDIT_CONTROL_INPUT);
-#ifndef _WIN32
-    AddString(NULL, "network.save", 779, "", BUTTON_CONTROL_STANDARD);
-#endif
-    AddSeparator(NULL, "network.sep1");
-#endif
-  }
-  AddBool(net, "network.usehttpproxy", 708, false);
-  AddString(net, "network.httpproxyserver", 706, "", EDIT_CONTROL_INPUT);
-  AddString(net, "network.httpproxyport", 730, "8080", EDIT_CONTROL_NUMBER_INPUT, false, 707);
-  AddString(net, "network.httpproxyusername", 1048, "", EDIT_CONTROL_INPUT);
-  AddString(net, "network.httpproxypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT,true,733);
-  AddInt(net, "network.bandwidth", 14041, 0, 0, 512, 100*1024, SPIN_CONTROL_INT_PLUS, MASK_KBPS, TEXT_OFF);
 
   // appearance settings
   AddGroup(7, 480);
@@ -898,20 +899,30 @@ CSettingsGroup *CGUISettings::GetGroup(int groupID)
   return NULL;
 }
 
+void CGUISettings::AddSetting(CSettingsCategory* cat, CSetting* setting)
+{
+  if (!setting)
+    return;
+
+  if (cat)
+    cat->m_settings.push_back(setting);
+  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(setting->GetSetting()).ToLower(), setting));
+}
+
 void CGUISettings::AddSeparator(CSettingsCategory* cat, const char *strSetting)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingSeparator *pSetting = new CSettingSeparator(iOrder, CStdString(strSetting).ToLower());
   if (!pSetting) return;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 void CGUISettings::AddBool(CSettingsCategory* cat, const char *strSetting, int iLabel, bool bData, int iControlType)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingBool* pSetting = new CSettingBool(iOrder, CStdString(strSetting).ToLower(), iLabel, bData, iControlType);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 bool CGUISettings::GetBool(const char *strSetting) const
 {
@@ -959,10 +970,10 @@ void CGUISettings::ToggleBool(const char *strSetting)
 
 void CGUISettings::AddFloat(CSettingsCategory* cat, const char *strSetting, int iLabel, float fData, float fMin, float fStep, float fMax, int iControlType)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingFloat* pSetting = new CSettingFloat(iOrder, CStdString(strSetting).ToLower(), iLabel, fData, fMin, fStep, fMax, iControlType);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 float CGUISettings::GetFloat(const char *strSetting) const
@@ -1003,39 +1014,36 @@ void CGUISettings::LoadMasterLock(TiXmlElement *pRootElement)
     LoadFromXML(pRootElement, it);
 }
 
-
 void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingInt* pSetting = new CSettingInt(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, strFormat);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, int iFormat, int iLabelMin/*=-1*/)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingInt* pSetting = new CSettingInt(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, iFormat, iLabelMin);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
-void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting,
-                          int iLabel, int iData, const map<int,int>& entries,
-                          int iControlType)
+void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, const map<int,int>& entries, int iControlType)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingInt* pSetting = new CSettingInt(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, entries, iControlType);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 void CGUISettings::AddHex(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingHex* pSetting = new CSettingHex(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, strFormat);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 int CGUISettings::GetInt(const char *strSetting) const
@@ -1068,26 +1076,26 @@ void CGUISettings::SetInt(const char *strSetting, int iSetting)
 
 void CGUISettings::AddString(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingString* pSetting = new CSettingString(iOrder, CStdString(strSetting).ToLower(), iLabel, strData, iControlType, bAllowEmpty, iHeadingString);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 void CGUISettings::AddPath(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingPath* pSetting = new CSettingPath(iOrder, CStdString(strSetting).ToLower(), iLabel, strData, iControlType, bAllowEmpty, iHeadingString);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 void CGUISettings::AddDefaultAddon(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, const TYPE type)
 {
-  int iOrder = cat?++cat->m_entries:0;
+  int iOrder = cat ? cat->m_settings.size() : 0;
   CSettingAddon* pSetting = new CSettingAddon(iOrder, CStdString(strSetting).ToLower(), iLabel, strData, type);
   if (!pSetting) return ;
-  settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
+  AddSetting(cat, pSetting);
 }
 
 const CStdString &CGUISettings::GetString(const char *strSetting, bool bPrompt /* = true */) const
@@ -1148,14 +1156,23 @@ CSetting *CGUISettings::GetSetting(const char *strSetting)
     return NULL;
 }
 
-// get all the settings beginning with the term "strGroup"
-void CGUISettings::GetSettingsGroup(const char *strGroup, vecSettings &settings)
+// get all the settings beginning belonging to the "cat" category
+void CGUISettings::GetSettingsGroup(CSettingsCategory* cat, vecSettings &settings)
 {
+  if (!cat)
+    return;
+
   vecSettings unorderedSettings;
-  for (mapIter it = settingsMap.begin(); it != settingsMap.end(); it++)
+  if (cat->m_settings.size())
+    unorderedSettings.insert(unorderedSettings.begin(), cat->m_settings.begin(), cat->m_settings.end());
+  else
   {
-    if ((*it).first.Left(strlen(strGroup)).Equals(strGroup) && (*it).second->GetOrder() > 0 && !(*it).second->IsAdvanced())
-      unorderedSettings.push_back((*it).second);
+    CStdString strGroup = cat->m_strCategory;
+    for (mapIter it = settingsMap.begin(); it != settingsMap.end(); it++)
+    {
+      if ((*it).first.Left(strGroup.size()).Equals(strGroup) && (*it).second->GetOrder() > 0 && !(*it).second->IsAdvanced())
+        unorderedSettings.push_back((*it).second);
+    }
   }
   // now order them...
   sort(unorderedSettings.begin(), unorderedSettings.end(), sortsettings());

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -394,13 +394,12 @@ public:
   {
     m_strCategory = strCategory;
     m_labelID = labelID;
-    m_entries = 0;
   }
   ~CSettingsCategory() {};
 
   CStdString m_strCategory;
   int m_labelID;
-  int m_entries;
+  std::vector<CSetting*> m_settings;
 };
 
 typedef std::vector<CSettingsCategory *> vecSettingsCategory;
@@ -450,6 +449,8 @@ public:
   CSettingsCategory* AddCategory(int groupID, const char *strCategory, int labelID);
   CSettingsGroup *GetGroup(int windowID);
 
+  void AddSetting(CSettingsCategory* cat, CSetting* setting);
+
   void AddBool(CSettingsCategory* cat, const char *strSetting, int iLabel, bool bSetting, int iControlType = CHECKMARK_CONTROL);
   bool GetBool(const char *strSetting) const;
   void SetBool(const char *strSetting, bool bSetting);
@@ -480,7 +481,7 @@ public:
 
   CSetting *GetSetting(const char *strSetting);
 
-  void GetSettingsGroup(const char *strGroup, vecSettings &settings);
+  void GetSettingsGroup(CSettingsCategory* cat, vecSettings &settings);
   void LoadXML(TiXmlElement *pRootElement, bool hideSettings = false);
   void SaveXML(TiXmlNode *pRootNode);
   void LoadMasterLock(TiXmlElement *pRootElement);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -346,7 +346,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
   if (!group)
     return;
   vecSettings settings;
-  g_guiSettings.GetSettingsGroup(m_vecSections[m_iSection]->m_strCategory, settings);
+  g_guiSettings.GetSettingsGroup(m_vecSections[m_iSection], settings);
   int iControlID = CONTROL_START_CONTROL;
   for (unsigned int i = 0; i < settings.size(); i++)
   {


### PR DESCRIPTION
This commit replaces the current "Network" group in the settings with a "Services" group. For that it moves the "Internet Access" category, which was part of the "Network" group into the "System" group and splits the different service settings which are currently in the "Services" category of the "Network" group into different categories themselves (like "UPnP", "AirPlay", "Webserver" etc). This should make it a lot easier to find those specific settings. Currently the "Services" category is so badly overloaded that you have to scroll down multiple times in Confluence to finally get to the AirPlay-related settings etc.

While I reshuffled those settings I noticed that it was necessary to rename all the settings to something like "< category >.< setting >" which would have broken backwards compatibility with the current settings/guisettings.xml. So what I did is I took advantage of the fact that when calling AddFoo (AddString, AddInt etc) for every setting in CGUISettings::Initialize() we also provide the category the setting belongs to. So I added a vector of settings to every category which allows faster access/finding of all settings belonging to a certain category.

This commit also fixes Confluence but all other skins would need adjustments because the windowname changed from "NetworkSettings" to "ServiceSettings". What I didn't fix in confluence was the image displayed when the new "Services" button is focused. We can either remove the old network-related image and introduce a new one for services or we can just use the network image for services (as all the services are network-related).
