### PR TITLE
python: close WSGI iterable on completion

### DIFF
--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -271,6 +271,15 @@ void CHTTPPythonWsgiInvoker::executeScript(void *fp, const std::string &script, 
     m_wsgiResponse->Append(result);
   }
 
+  // Call optional close method on iterator
+  if (PyObject_HasAttrString(pyResultIterator, (char*)"close") == 1)
+  {
+    if (PyObject_CallMethod(pyResultIterator, (char*)"close", NULL) == NULL)
+    {
+      CLog::Log(LOGERROR, "CHTTPPythonWsgiInvoker: failed close iterator object for WSGI script \"%s\"", script.c_str());
+    }
+  }
+
 cleanup:
   if (pyIterResult != NULL)
     Py_DECREF(pyIterResult);


### PR DESCRIPTION
This method must be called (if it exists) according to spec